### PR TITLE
Python gitignore: Add.nox

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -38,6 +38,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache


### PR DESCRIPTION
**Reasons for making this change:**

Ignore `.nox` which is the directory [nox](http://nox.readthedocs.io/en/latest/index.html) automation tool uses. `nox` is awesome and I am sure the community will start looking into it more.

**Links to documentation supporting these rule changes:** 

[nox](http://nox.readthedocs.io/en/latest/index.html)